### PR TITLE
Fix some typing

### DIFF
--- a/src/React/Redux.js
+++ b/src/React/Redux.js
@@ -73,8 +73,16 @@ exports.dispatch_ = function dispatch_(thisForeign, action){
   };
 };
 
-exports.applyMiddleware = function applyMiddleware(middlewares){
-  var middlewaresForeign = middlewares.map(function(middleware){
+exports.applyMiddleware = function applyMiddleware(middleware){
+  var middlewareEnhancerForeign = Redux.applyMiddleware.apply(Redux, [middleware]);
+
+  var result = exports.fromEnhancerForeign(middlewareEnhancerForeign);
+
+  return result;
+};
+
+exports.composeMiddleware = function composeMiddleware(middlewareA) {
+  return function(middlewareB) {
     return function(middlewareAPIForeign){
       return function(nextForeign){
         return function(actionForeign){
@@ -106,19 +114,13 @@ exports.applyMiddleware = function applyMiddleware(middlewares){
 
           var action = actionForeign.action;
 
-          var result = middleware(middlewareAPI)(next)(action)();
+          var result = middlewareB(middlewareAPI)(middlewareA(middlewareAPI)(next))(action)();
 
           return result;
         };
       };
-    }
-  });
-
-  var middlewareEnhancerForeign = Redux.applyMiddleware.apply(Redux, middlewaresForeign);
-
-  var result = exports.fromEnhancerForeign(middlewareEnhancerForeign);
-
-  return result;
+    };
+  };
 };
 
 exports.fromEnhancerForeign = function fromEnhancerForeign(enhancerForeign){

--- a/src/React/Redux.purs
+++ b/src/React/Redux.purs
@@ -48,7 +48,7 @@ import Unsafe.Coerce (unsafeCoerce)
 
 import React as React
 
-type ReduxReactClass' state props action = ReduxReactClass state Unit props action
+type ReduxReactClass' props state action = ReduxReactClass Unit props state action
 
 type Reducer action state = action -> state -> state
 
@@ -118,7 +118,7 @@ createProviderElement store reduxClass = React.createElement providerClass { sto
 createClass :: forall eff f action props props' state state'. MonadEff (ReduxEffect eff) f
             => Getter' (Tuple state props) props'
             -> Spec props' state' eff f action
-            -> ReduxReactClass state props props' action
+            -> ReduxReactClass props props' state action
 createClass slens spec_ = runFn3 connect_ Tuple (view slens) reactClass
   where
   reactClass :: React.ReactClass props'
@@ -138,19 +138,19 @@ createClass slens spec_ = runFn3 connect_ Tuple (view slens) reactClass
     dispatch :: React.ReactThis props' state' -> f action -> f action
     dispatch this action = action >>= liftEff <<< runFn2 dispatch_ this
 
-createClass' :: forall eff f action props state. MonadEff (ReduxEffect eff) f => Getter' state props -> Spec props Unit eff f action -> ReduxReactClass' state props action
+createClass' :: forall eff f action props state. MonadEff (ReduxEffect eff) f => Getter' state props -> Spec props Unit eff f action -> ReduxReactClass' props state action
 createClass' slens spec_ = createClass slens' spec_
   where
   slens' :: Getter' (Tuple state Unit) props
   slens' = to (view slens <<< fst)
 
-createElement :: forall state props props' action. ReduxReactClass state props props' action -> props -> Array React.ReactElement -> React.ReactElement
+createElement :: forall state props props' action. ReduxReactClass props props' state action -> props -> Array React.ReactElement -> React.ReactElement
 createElement reduxClass = React.createElement reactClass
   where
   reactClass :: React.ReactClass props
   reactClass = unsafeCoerce reduxClass
 
-createElement' :: forall state props action. ReduxReactClass' state props action -> Array React.ReactElement -> React.ReactElement
+createElement' :: forall state props action. ReduxReactClass' props state action -> Array React.ReactElement -> React.ReactElement
 createElement' reduxClass = createElement reduxClass unit
 
 createStore :: forall eff action state. Reducer action state -> state -> Enhancer eff action state -> Eff (ReduxEffect eff) (Store action state)
@@ -174,7 +174,7 @@ foreign import data Store :: * -> * -> *
 
 foreign import data ReduxReactClass :: * -> * -> * -> * -> *
 
-foreign import connect_ :: forall state props props' action. Fn3 (state -> props -> Tuple state props) (Tuple state props -> props') (React.ReactClass props') (ReduxReactClass state props props' action)
+foreign import connect_ :: forall state props props' action. Fn3 (state -> props -> Tuple state props) (Tuple state props -> props') (React.ReactClass props') (ReduxReactClass props props' state action)
 
 foreign import dispatch_ :: forall eff action props state. Fn2 (React.ReactThis props state) action (Eff (ReduxEffect eff) action)
 

--- a/src/React/Redux.purs
+++ b/src/React/Redux.purs
@@ -35,15 +35,19 @@ module React.Redux
   , fromEnhancerForeign
   ) where
 
-import React as React
+import Prelude (Unit, (>>=), (<<<), const, pure, id, unit)
+
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (class MonadEff, liftEff)
+
 import Data.Either (Either, either)
 import Data.Function.Uncurried (Fn2, Fn3, runFn2, runFn3)
 import Data.Lens (Getter', Lens', Prism', matching, set, to, view)
 import Data.Tuple (Tuple(..), fst)
-import Prelude (Unit, const, id, pure, unit, (<<<), (>>=))
+
 import Unsafe.Coerce (unsafeCoerce)
+
+import React as React
 
 type ReduxReactClass' props state action = ReduxReactClass Unit props state action
 
@@ -109,10 +113,10 @@ spec getInitialState render =
 spec' :: forall props eff f action. Render props Unit eff f action -> Spec props Unit eff f action
 spec' = spec (\_ _ -> pure unit)
 
-createProviderElement :: forall action props state. Store action state -> ReduxReactClass' state props action -> React.ReactElement
+createProviderElement :: forall props state action. Store action state -> ReduxReactClass' props state action -> React.ReactElement
 createProviderElement store reduxClass = React.createElement providerClass { store: store } [ createElement' reduxClass [] ]
 
-createClass :: forall eff f action props props' state state'. MonadEff (ReduxEffect eff) f
+createClass :: forall eff f props props' state state' action. MonadEff (ReduxEffect eff) f
             => Getter' (Tuple state props) props'
             -> Spec props' state' eff f action
             -> ReduxReactClass props props' state action
@@ -135,25 +139,25 @@ createClass slens spec_ = runFn3 connect_ Tuple (view slens) reactClass
     dispatch :: React.ReactThis props' state' -> f action -> f action
     dispatch this action = action >>= liftEff <<< runFn2 dispatch_ this
 
-createClass' :: forall eff f action props state. MonadEff (ReduxEffect eff) f => Getter' state props -> Spec props Unit eff f action -> ReduxReactClass' props state action
+createClass' :: forall eff f props state action. MonadEff (ReduxEffect eff) f => Getter' state props -> Spec props Unit eff f action -> ReduxReactClass' props state action
 createClass' slens spec_ = createClass slens' spec_
   where
   slens' :: Getter' (Tuple state Unit) props
   slens' = to (view slens <<< fst)
 
-createElement :: forall state props props' action. ReduxReactClass props props' state action -> props -> Array React.ReactElement -> React.ReactElement
+createElement :: forall props props' state action. ReduxReactClass props props' state action -> props -> Array React.ReactElement -> React.ReactElement
 createElement reduxClass = React.createElement reactClass
   where
   reactClass :: React.ReactClass props
   reactClass = unsafeCoerce reduxClass
 
-createElement' :: forall state props action. ReduxReactClass' props state action -> Array React.ReactElement -> React.ReactElement
+createElement' :: forall props state action. ReduxReactClass' props state action -> Array React.ReactElement -> React.ReactElement
 createElement' reduxClass = createElement reduxClass unit
 
-createStore :: forall eff action state. Reducer action state -> state -> Enhancer eff action state -> Eff (ReduxEffect eff) (Store action state)
+createStore :: forall eff state action. Reducer action state -> state -> Enhancer eff action state -> Eff (ReduxEffect eff) (Store action state)
 createStore = runFn3 createStore_
 
-createStore' :: forall eff action state. Reducer action state -> state -> Eff (ReduxEffect eff) (Store action state)
+createStore' :: forall eff state action. Reducer action state -> state -> Eff (ReduxEffect eff) (Store action state)
 createStore' reducer state = createStore reducer state id
 
 reducerOptic :: forall state state' action action'. Lens' state state' -> Prism' action action' -> Reducer action' state' -> Reducer action state
@@ -171,15 +175,15 @@ foreign import data Store :: * -> * -> *
 
 foreign import data ReduxReactClass :: * -> * -> * -> * -> *
 
-foreign import connect_ :: forall state props props' action. Fn3 (state -> props -> Tuple state props) (Tuple state props -> props') (React.ReactClass props') (ReduxReactClass props props' state action)
+foreign import connect_ :: forall props props' state action. Fn3 (state -> props -> Tuple state props) (Tuple state props -> props') (React.ReactClass props') (ReduxReactClass props props' state action)
 
-foreign import dispatch_ :: forall eff action props state. Fn2 (React.ReactThis props state) action (Eff (ReduxEffect eff) action)
+foreign import dispatch_ :: forall eff props state action. Fn2 (React.ReactThis props state) action (Eff (ReduxEffect eff) action)
 
-foreign import providerClass :: forall action state. React.ReactClass { store :: Store action state }
+foreign import providerClass :: forall state action. React.ReactClass { store :: Store action state }
 
-foreign import createStore_ :: forall eff action state. Fn3 (Reducer action state) state (Enhancer eff action state) (Eff (ReduxEffect eff) (Store action state))
+foreign import createStore_ :: forall eff state action. Fn3 (Reducer action state) state (Enhancer eff action state) (Eff (ReduxEffect eff) (Store action state))
 
-foreign import composeMiddleware :: forall eff state result storeAction actionA actionB actionC. Middleware eff storeAction state result actionB actionC -> Middleware eff storeAction state result actionA actionB -> Middleware eff storeAction state result actionA actionC
+foreign import composeMiddleware :: forall eff state result storeAction actionA actionB actionC. Middleware eff storeAction state result actionA actionB -> Middleware eff storeAction state result actionB actionC -> Middleware eff storeAction state result actionA actionC
 
 foreign import applyMiddleware :: forall eff state result action storeAction. Middleware eff storeAction state result action storeAction -> Enhancer eff storeAction state
 


### PR DESCRIPTION
#* Parameterize `ReduxReactClass` by an action type, change type parameters order to make it uniform with React-bindings Spec: props goes first, then state, and actions come last, as they're addition here

* Alter type signature of `Middleware`, to reflect the fact that it can be composed and thus next middleware in chain can receive different action type.

TODO: `semigroupoid` instance for `Middleware` - that seems to require `Middleware` to be `newtype` rather than type synonym, which has some ugly consequences...

Also, it's late already and I'm not 100% sure I've made everything right, but openened this PR so that you can play around/check. I've also modified Example app to include some (useless) different Action types showing how the composition works: https://github.com/BartAdv/purescript-react-redux-example/tree/wip