### PR TITLE
Apply middleware  API function earlier

### DIFF
--- a/src/React/Redux.js
+++ b/src/React/Redux.js
@@ -4,10 +4,8 @@ var Redux = require('redux');
 
 var ReactRedux = require('react-redux');
 
-var actionType = '@@PURESCRIPT_REACT_REDUX';
-
 function startsWithActionType(actionForeign) {
-  var index = actionForeign.type.indexOf(actionType);
+  var index = actionForeign.type.indexOf('@@PURESCRIPT_REACT_REDUX');
 
   return index === 0;
 }
@@ -16,7 +14,7 @@ function makeActionForeign(action) {
   var constructorName = action.constructor && action.constructor.name ? action.constructor.name : 'UnknownConstructorName';
 
   var actionForeign = {
-    type: actionType + '/' + constructorName,
+    type: '@@PURESCRIPT_REACT_REDUX/' + constructorName,
     action: action
   };
 


### PR DESCRIPTION
This change enables a hack that is employed in a fairly famous library
called "redux-saga", where the middleware api is captured during the
call to the "applyMiddleware" and subsequently used to dispatch more
actions and peek into state.

I use the word "hack" here, because for this to be any useful in a pure language, I have to use `unsafePerformEff`, which is a hack at best.

Note that this change does neither force this hack on others or
encourage it. There should be no observable change to existing
codebases.

Applying this function earlier also means that we don't have to redefine
the function on every invocation and re-create the middlewareApi object.

Finally, this is consistent with the implementation in the redux source
code: https://github.com/reactjs/redux/blob/e2e9648b264224af68add35431898dafe26b0a09/src/applyMiddleware.js

--

I also inlined the `actionType` as it seems it gets compiled away when building for react native, resulting in "variable actionType not found"